### PR TITLE
Collect metadata

### DIFF
--- a/.github/workflows/predict-parallel.yml
+++ b/.github/workflows/predict-parallel.yml
@@ -5,6 +5,9 @@ on:
       model-id:
         required: true
         type: string
+      sample-only:
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -29,6 +32,7 @@ jobs:
       numerator: ${{ matrix.numerator }}
       denominator: 50
       model-id: ${{ inputs.model-id }}
+      sample-only: ${{ inputs.sample-only }}
       SHA: ${{ github.sha }}
 
     secrets: inherit

--- a/.github/workflows/predict-parallel.yml
+++ b/.github/workflows/predict-parallel.yml
@@ -13,6 +13,15 @@ permissions:
   contents: read
 
 jobs:
+  start-time:
+    runs-on: ubuntu-latest
+    outputs:
+      start_time: ${{ steps.start-time.outputs.start_time }}
+    steps:
+      - name: Get start time
+        id: start-time
+        run: echo "start_time=$(date +%s)" >> "$GITHUB_OUTPUT"
+
   matrix-inference:
     if: github.repository != 'ersilia-os/eos-template'
 
@@ -38,7 +47,7 @@ jobs:
     secrets: inherit
   
   trigger-serve-pipeline:
-    needs: matrix-inference
+    needs: [start-time, matrix-inference]
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch
@@ -47,4 +56,4 @@ jobs:
           token: ${{ secrets.API_TOKEN_GITHUB }}
           repository: ersilia-os/model-inference-pipeline
           event-type: dispatch-serving-after-prediction
-          client-payload: '{"model-id": "${{ inputs.model-id }}", "sha": "${{ github.sha }}"}'
+          client-payload: '{"model-id": "${{ inputs.model-id }}", "sha": "${{ github.sha }}", "start_time": "${{ needs.start-time.outputs.start_time }}"}'

--- a/.github/workflows/predict-parallel.yml
+++ b/.github/workflows/predict-parallel.yml
@@ -7,7 +7,7 @@ on:
         type: string
       sample-only:
         required: false
-        type: string
+        type: number
 
 permissions:
   contents: read

--- a/.github/workflows/predict-parallel.yml
+++ b/.github/workflows/predict-parallel.yml
@@ -7,7 +7,7 @@ on:
         type: string
       sample-only:
         required: false
-        type: number
+        type: string
 
 permissions:
   contents: read

--- a/.github/workflows/predict-serve-sample.yml
+++ b/.github/workflows/predict-serve-sample.yml
@@ -1,0 +1,82 @@
+name: Predict and Serve using Subset of Reference Library
+on:
+    workflow_dispatch:
+        inputs:
+            model-id:
+                required: true
+                type: string
+            n_samples:
+                required: true
+                type: string
+
+permissions:
+    contents: read
+
+jobs:
+    inference:
+        if: github.repository != 'ersilia-os/eos-template'
+        runs-on: ubuntu-latest
+
+        steps:
+            -   name: Print system details
+                run: sudo lshw -short
+
+            -   name: Check into ersilia-os/ersilia repo
+                uses: actions/checkout@v3
+                with:
+                    repository: ersilia-os/ersilia
+
+            -   name: Configure AWS credentials
+                uses: aws-actions/configure-aws-credentials@master
+                with:
+                    aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+                    aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                    aws-region: eu-central-1
+            
+            -   name: Save pipeline start time
+                run: |
+                    echo "$(date +%s)" > meta.txt
+
+            -   name: Get input library
+                run: |
+                    echo "Getting ${{ inputs.n_samples }} from reference library"
+                    filename="reference_library.csv"
+                    aws s3 cp s3://precalculations-bucket/"$filename" $filename
+                    
+                    # Get first n_samples+1 lines from reference library
+                    head -n $(( ${{ inputs.n_samples }} + 1 )) $filename > subset_$filename.csv
+
+            -   name: Add conda to system path
+                run: echo $CONDA/bin >> $GITHUB_PATH
+
+            -   name: Source conda
+                run: source $CONDA/etc/profile.d/conda.sh
+
+            -   name: Set Python to 3.10.10
+                run: conda install -y python=3.10.10
+            
+            -   name: Install dependencies
+                run: |
+                    source activate
+                    conda init
+                    conda install git-lfs -c conda-forge
+                    git-lfs install
+                    conda install gh -c conda-forge
+            
+            -   name: Install ersilia
+                run: |
+                    source activate
+                    python --version
+                    echo "After conda init"
+                    conda init
+                    python -m pip install -e .[test]
+            
+            -   name: Run inference and upload outputs to S3
+                run: |
+                    source activate
+                    echo "Sample model id selected: ${{ inputs.model-id }}"
+                    ersilia fetch ${{ inputs.model-id }}
+                    ersilia serve ${{ inputs.model-id }}
+                    echo "${{ inputs.model-id }} succesfully fetched and served"
+                    ersilia api -i subset_$filename.csv -o ../${{ github.SHA }}_sample.csv
+                    aws s3 cp ../${{ github.SHA }}_sample.csv s3://precalculations-bucket/sample/${{ inputs.model-id }}/${{ github.SHA }}_sample.csv

--- a/.github/workflows/predict.yml
+++ b/.github/workflows/predict.yml
@@ -44,7 +44,11 @@ jobs:
            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
            aws-region: eu-central-1
-      
+
+      - name: Save pipeline start time
+        run: |
+          echo "$(date +%s)" > meta.txt
+
       - name: Get input library
         run: |
           if [[ ${{ inputs.sample-only }} ]]; then

--- a/.github/workflows/predict.yml
+++ b/.github/workflows/predict.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           numerator=${{ inputs.numerator }}
           denominator=${{ inputs.denominator }}
-          filename="reference_library.csv"
+          filename="data/reference_library_100.csv"
           
           ## Total # lines in given reference library
           total_lines=$(wc -l < "$filename")

--- a/.github/workflows/predict.yml
+++ b/.github/workflows/predict.yml
@@ -48,10 +48,10 @@ jobs:
       - name: Get input library
         run: |
           if [[ ${{ inputs.sample-only }} ]]; then
-            echo "Running pipeline on subset of reference library"
+            echo "Getting subset of reference library"
             filename="reference_library_100.csv"
           else
-            echo "Running pipeline on whole reference library"
+            echo "Getting whole reference library"
             filename="reference_library.csv"
           fi
           aws s3 cp s3://precalculations-bucket/"$filename" $filename
@@ -60,7 +60,11 @@ jobs:
         run: |
           numerator=${{ inputs.numerator }}
           denominator=${{ inputs.denominator }}
-
+          if [[ ${{ inputs.sample-only }} ]]; then
+            filename="reference_library_100.csv"
+          else
+            filename="reference_library.csv"
+          fi
           
           ## Total # lines in given reference library
           total_lines=$(wc -l < "$filename")

--- a/.github/workflows/predict.yml
+++ b/.github/workflows/predict.yml
@@ -14,7 +14,7 @@ on:
         type: string
       sample-only:
         required: false
-        type: number
+        type: string
       SHA:
         required: true
         type: string

--- a/.github/workflows/predict.yml
+++ b/.github/workflows/predict.yml
@@ -129,3 +129,7 @@ jobs:
           ersilia api -i $(printf "partition_%04d.csv" $index) -o ../${{ inputs.SHA }}$(printf "_%04d.csv" $numerator)
 
           aws s3 cp ../${{ inputs.SHA }}$(printf "_%04d.csv" $numerator) s3://precalculations-bucket/out/${{ inputs.model-id }}/${{ inputs.SHA }}$(printf "_%04d.csv" $numerator)
+
+      - name: Write pipeline start time to s3
+        run: |
+          .venv/bin/python3 scripts/write_metadata_to_s3.py ${{ inputs.model-id }} --pipeline_start "$(cat meta.txt)"

--- a/.github/workflows/predict.yml
+++ b/.github/workflows/predict.yml
@@ -14,7 +14,7 @@ on:
         type: string
       sample-only:
         required: false
-        type: string
+        type: number
       SHA:
         required: true
         type: string
@@ -53,7 +53,7 @@ jobs:
         run: |
           if [[ ${{ inputs.sample-only }} ]]; then
             echo "Getting subset of reference library"
-            filename="reference_library_100.csv"
+            filename="reference_library_${{ inputs.sample-only }}.csv"
           else
             echo "Getting whole reference library"
             filename="reference_library.csv"
@@ -65,7 +65,7 @@ jobs:
           numerator=${{ inputs.numerator }}
           denominator=${{ inputs.denominator }}
           if [[ ${{ inputs.sample-only }} ]]; then
-            filename="reference_library_100.csv"
+            filename="reference_library_${{ inputs.sample-only }}.csv"
           else
             filename="reference_library.csv"
           fi

--- a/.github/workflows/predict.yml
+++ b/.github/workflows/predict.yml
@@ -12,6 +12,9 @@ on:
       model-id:
         required: true
         type: string
+      sample-only:
+        required: false
+        type: string
       SHA:
         required: true
         type: string
@@ -44,13 +47,20 @@ jobs:
       
       - name: Get input library
         run: |
-          aws s3 cp s3://precalculations-bucket/reference_library.csv reference_library.csv
+          if [[ ${{ inputs.sample-only }} ]]; then
+            echo "Running pipeline on subset of reference library"
+            filename="reference_library_100.csv"
+          else
+            echo "Running pipeline on whole reference library"
+            filename="reference_library.csv"
+          fi
+          aws s3 cp s3://precalculations-bucket/"$filename" $filename
 
       - name: Split library by partition variables
         run: |
           numerator=${{ inputs.numerator }}
           denominator=${{ inputs.denominator }}
-          filename="data/reference_library_100.csv"
+
           
           ## Total # lines in given reference library
           total_lines=$(wc -l < "$filename")

--- a/.github/workflows/predict.yml
+++ b/.github/workflows/predict.yml
@@ -45,10 +45,6 @@ jobs:
            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
            aws-region: eu-central-1
 
-      - name: Save pipeline start time
-        run: |
-          echo "$(date +%s)" > meta.txt
-
       - name: Get input library
         run: |
           if [[ ${{ inputs.sample-only }} ]]; then
@@ -120,7 +116,6 @@ jobs:
         run: |
           numerator=${{ inputs.numerator }}
           index=$((numerator - 1))
-          
           source activate
           echo "Sample model id selected: ${{ inputs.model-id }}"
           ersilia fetch ${{ inputs.model-id }}
@@ -129,7 +124,3 @@ jobs:
           ersilia api -i $(printf "partition_%04d.csv" $index) -o ../${{ inputs.SHA }}$(printf "_%04d.csv" $numerator)
 
           aws s3 cp ../${{ inputs.SHA }}$(printf "_%04d.csv" $numerator) s3://precalculations-bucket/out/${{ inputs.model-id }}/${{ inputs.SHA }}$(printf "_%04d.csv" $numerator)
-
-      - name: Write pipeline start time to s3
-        run: |
-          python scripts/write_metadata_to_s3.py ${{ inputs.model-id }} --pipeline_start "$(cat meta.txt)"

--- a/.github/workflows/predict.yml
+++ b/.github/workflows/predict.yml
@@ -132,4 +132,4 @@ jobs:
 
       - name: Write pipeline start time to s3
         run: |
-          .venv/bin/python3 scripts/write_metadata_to_s3.py ${{ inputs.model-id }} --pipeline_start "$(cat meta.txt)"
+          python scripts/write_metadata_to_s3.py ${{ inputs.model-id }} --pipeline_start "$(cat meta.txt)"

--- a/.github/workflows/serve-parallel.yml
+++ b/.github/workflows/serve-parallel.yml
@@ -36,5 +36,6 @@ jobs:
     with:
       model: ${{ github.event.client_payload.model-id }}
       sha: ${{ github.event.client_payload.sha }}
+      start_time: ${{ github.event.client_payload.start_time }}
       partition: ${{ matrix.partition }}
     secrets: inherit

--- a/.github/workflows/serve.yml
+++ b/.github/workflows/serve.yml
@@ -9,6 +9,9 @@ on:
       sha:
         required: true
         type: string
+      start_time:
+        required: true
+        type: string
       partition:
         required: true
         type: number
@@ -19,6 +22,9 @@ on:
         required: true
         type: string
       sha:
+        required: true
+        type: string
+      start_time:
         required: true
         type: string
       partition:
@@ -52,10 +58,7 @@ jobs:
         run: |
           .venv/bin/python3 scripts/write_predictions_to_dynamodb.py ${{ inputs.model }} ${{ inputs.sha }} ${{ inputs.partition }}
 
-      - name: save pipeline end time
-        run: |
-          echo "$(date +%s)" >> meta.txt
-
       - name: write pipeline end time to s3
         run: |
-          .venv/bin/python3 scripts/write_metadata_to_s3.py ${{ inputs.model }} --pipeline_end "$(cat meta.txt)"
+          end_time=$(date +%s)
+          .venv/bin/python3 scripts/write_metadata_to_s3.py ${{ inputs.model }} --pipeline_start ${{ inputs.start_time }} --pipeline_end $end_time

--- a/.github/workflows/serve.yml
+++ b/.github/workflows/serve.yml
@@ -51,3 +51,11 @@ jobs:
       - name: serve predictions to dynamodb
         run: |
           .venv/bin/python3 scripts/write_predictions_to_dynamodb.py ${{ inputs.model }} ${{ inputs.sha }} ${{ inputs.partition }}
+
+      - name: save pipeline end time
+        run: |
+          echo "$(date +%s)" >> meta.txt
+
+      - name: write metadata of pipeline run to s3
+        run: |
+          .venv/bin/python3 scripts/write_metadata_to_s3.py ${{ inputs.model }} "$(cat meta.txt)"

--- a/.github/workflows/serve.yml
+++ b/.github/workflows/serve.yml
@@ -56,6 +56,6 @@ jobs:
         run: |
           echo "$(date +%s)" >> meta.txt
 
-      - name: write metadata of pipeline run to s3
+      - name: write pipeline end time to s3
         run: |
-          .venv/bin/python3 scripts/write_metadata_to_s3.py ${{ inputs.model }} "$(cat meta.txt)"
+          .venv/bin/python3 scripts/write_metadata_to_s3.py ${{ inputs.model }} --pipeline_end "$(cat meta.txt)"

--- a/precalculator/models.py
+++ b/precalculator/models.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import pandera as pa
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Prediction(BaseModel):
@@ -21,10 +21,10 @@ class BasePredictionSchema(pa.DataFrameModel):
 class Metadata(BaseModel):
     """Dataclass to represent metadata for a pipeline run"""
 
-    model_id: str
-    preds_in_store: bool
-    total_unique_preds: int
-    preds_last_updated: int
-    pipeline_latest_start_time: int
-    pipeline_latest_duration: int
-    pipeline_meta_s3_uri: str
+    model_id: str = Field(default="")
+    preds_in_store: bool = Field(default=False)
+    total_unique_preds: int = Field(default=0)
+    preds_last_updated: int = Field(default=0)
+    pipeline_latest_start_time: int = Field(default=0)
+    pipeline_latest_duration: int = Field(default=0)
+    pipeline_meta_s3_uri: str = Field(default="")

--- a/precalculator/models.py
+++ b/precalculator/models.py
@@ -16,3 +16,15 @@ class Prediction(BaseModel):
 class BasePredictionSchema(pa.DataFrameModel):
     key: str = pa.Field(str_matches=(r"^[a-zA-Z]{14}-[a-zA-Z]{10}-[a-zA-Z]{1}$"))
     input: str
+
+
+class Metadata(BaseModel):
+    """Dataclass to represent metadata for a pipeline run"""
+
+    model_id: str
+    preds_in_store: bool
+    total_unique_preds: int
+    preds_last_updated: int
+    pipeline_latest_start_time: int
+    pipeline_latest_duration: int
+    pipeline_meta_s3_uri: str

--- a/precalculator/read.py
+++ b/precalculator/read.py
@@ -1,6 +1,7 @@
+import boto3
 import pandas as pd
 
-from precalculator.models import BasePredictionSchema, Prediction
+from precalculator.models import BasePredictionSchema, Metadata, Prediction
 
 # def read_predictions_from_s3(model_id: str, s3_config:) -> DataFrame[PredictionSchema]
 
@@ -36,3 +37,41 @@ def get_predictions_from_dataframe(model_id: str, prediction_df: pd.DataFrame) -
         )
         for prediction in predictions
     ]
+
+
+def get_metadata(table_name: str, model_id: str, timestamps: str, s3_uri: str) -> Metadata:
+    """Generate a metadata object for a given model ID and pipeline run
+
+    Args:
+        model_id (str): ID of the model
+        timestamps (str): Start and end times of the pipeline run
+
+    Returns:
+        Metadata: Metadata object
+    """
+    client = boto3.client("dynamodb")
+
+    preds_in_store = False
+    total_unique_preds = 0
+    model_id_search = client.scan(
+        TableName=table_name,
+        FilterExpression="SK=:model_id",
+        ExpressionAttributeValues={":model_id": {"S": f"MODELID#{model_id}"}},
+        Select="COUNT",
+    )
+    if model_id_search["Count"] > 0:
+        preds_in_store = True
+        total_unique_preds = model_id_search["Count"]
+
+    start_time, end_time = map(int, timestamps.split())
+    duration = end_time - start_time
+
+    return Metadata(
+        model_id=model_id,
+        preds_in_store=preds_in_store,
+        total_unique_preds=total_unique_preds,
+        preds_last_updated=end_time,
+        pipeline_latest_start_time=start_time,
+        pipeline_latest_duration=duration,
+        pipeline_meta_s3_uri=s3_uri,
+    )

--- a/precalculator/read.py
+++ b/precalculator/read.py
@@ -1,9 +1,12 @@
+import json
+
 import boto3
 import pandas as pd
 
 from precalculator.models import BasePredictionSchema, Metadata, Prediction
 
 # def read_predictions_from_s3(model_id: str, s3_config:) -> DataFrame[PredictionSchema]
+s3_client = boto3.client("s3")
 
 
 def get_predictions_from_dataframe(model_id: str, prediction_df: pd.DataFrame) -> list[Prediction]:
@@ -39,39 +42,7 @@ def get_predictions_from_dataframe(model_id: str, prediction_df: pd.DataFrame) -
     ]
 
 
-def get_metadata(table_name: str, model_id: str, timestamps: str, s3_uri: str) -> Metadata:
-    """Generate a metadata object for a given model ID and pipeline run
-
-    Args:
-        model_id (str): ID of the model
-        timestamps (str): Start and end times of the pipeline run
-
-    Returns:
-        Metadata: Metadata object
-    """
-    client = boto3.client("dynamodb")
-
-    preds_in_store = False
-    total_unique_preds = 0
-    model_id_search = client.scan(
-        TableName=table_name,
-        FilterExpression="SK=:model_id",
-        ExpressionAttributeValues={":model_id": {"S": f"MODELID#{model_id}"}},
-        Select="COUNT",
-    )
-    if model_id_search["Count"] > 0:
-        preds_in_store = True
-        total_unique_preds = model_id_search["Count"]
-
-    start_time, end_time = map(int, timestamps.split())
-    duration = end_time - start_time
-
-    return Metadata(
-        model_id=model_id,
-        preds_in_store=preds_in_store,
-        total_unique_preds=total_unique_preds,
-        preds_last_updated=end_time,
-        pipeline_latest_start_time=start_time,
-        pipeline_latest_duration=duration,
-        pipeline_meta_s3_uri=s3_uri,
-    )
+def get_metadata(bucket: str, metadata_key: str) -> Metadata:
+    metadata_obj = s3_client.get_object(Bucket=bucket, Key=metadata_key)
+    metadata_json = json.loads(metadata_obj["Body"].read().decode("utf-8"))
+    return Metadata(**metadata_json)

--- a/precalculator/write.py
+++ b/precalculator/write.py
@@ -5,10 +5,8 @@ from decimal import Decimal
 from typing import List
 
 import boto3
-from botocore.exceptions import ClientError
 
 from precalculator.models import Metadata, Prediction
-from precalculator.read import get_metadata
 
 logger = logging.Logger("DynamoDBWriter")
 s3_client = boto3.client("s3")
@@ -33,42 +31,5 @@ def write_precalcs_batch_writer(dynamodb_table: str, precalcs: List[Prediction])
             )
 
 
-def _write_metadata(bucket: str, key: str, obj: Metadata) -> None:
-    s3_client.put_object(Bucket=bucket, Key=key, Body=json.dumps(obj.json()))
-
-
-def write_metadata_end(
-    table_name: str, bucket: str, model_id: str, end_time: int, metadata_key: str, s3_uri: str
-) -> None:
-    metadata = get_metadata(bucket, metadata_key)
-
-    model_id_search = dynamodb.scan(
-        TableName=table_name,
-        FilterExpression="SK=:model_id",
-        ExpressionAttributeValues={":model_id": {"S": f"MODELID#{model_id}"}},
-        Select="COUNT",
-    )
-    if model_id_search["Count"] > 0:
-        metadata.preds_in_store = True
-        metadata.total_unique_preds = model_id_search["Count"]
-
-    metadata.preds_last_updated = end_time
-
-    # this assumes that the pipeline start time is the current run's and has been written to metadata already...
-    metadata.pipeline_latest_duration = metadata.preds_last_updated - metadata.pipeline_latest_start_time
-
-    metadata.pipeline_meta_s3_uri = s3_uri
-
-    _write_metadata(bucket, metadata_key, metadata)
-
-
-def write_metadata_start(bucket: str, start_time: int, metadata_key: str) -> None:
-    try:
-        metadata = get_metadata(bucket, metadata_key)
-    except ClientError as e:
-        if e.response["Error"]["Code"] == "NoSuchKey":
-            metadata = Metadata()
-
-    metadata.pipeline_latest_start_time = start_time
-
-    _write_metadata(bucket, metadata_key, metadata)
+def write_metadata(bucket: str, metadata_key: str, metadata: Metadata) -> None:
+    s3_client.put_object(Bucket=bucket, Key=metadata_key, Body=json.dumps(metadata.json()))

--- a/precalculator/write.py
+++ b/precalculator/write.py
@@ -6,7 +6,7 @@ from typing import List
 
 import boto3
 
-from precalculator.models import Prediction
+from precalculator.models import Metadata, Prediction
 
 logger = logging.Logger("DynamoDBWriter")
 
@@ -28,3 +28,19 @@ def write_precalcs_batch_writer(dynamodb_table: str, precalcs: List[Prediction])
                     "Timestamp": str(time.time()),
                 }
             )
+
+
+def write_metadata(bucket: str, metadata_key: str, metadata: Metadata) -> None:
+    s3 = boto3.client("s3")
+
+    metadata_json = {
+        "model_id": metadata.model_id,
+        "preds_in_store": metadata.preds_in_store,
+        "total_unique_preds": metadata.total_unique_preds,
+        "preds_last_updated": metadata.preds_last_updated,
+        "pipeline_latest_start_time": metadata.pipeline_latest_start_time,
+        "pipeline_latest_duration": metadata.pipeline_latest_duration,
+        "pipeline_meta_s3_uri": metadata.pipeline_meta_s3_uri,
+    }
+
+    s3.put_object(Bucket=bucket, Key=metadata_key, Body=json.dumps(metadata_json))

--- a/precalculator/write.py
+++ b/precalculator/write.py
@@ -5,14 +5,17 @@ from decimal import Decimal
 from typing import List
 
 import boto3
+from botocore.exceptions import ClientError
 
 from precalculator.models import Metadata, Prediction
+from precalculator.read import get_metadata
 
 logger = logging.Logger("DynamoDBWriter")
+s3_client = boto3.client("s3")
+dynamodb = boto3.resource("dynamodb")
 
 
 def write_precalcs_batch_writer(dynamodb_table: str, precalcs: List[Prediction]) -> None:
-    dynamodb = boto3.resource("dynamodb")
     table = dynamodb.Table(dynamodb_table)
 
     logger.info(f"Writing {len(precalcs)} using the boto3 batch writer to DynamoDB")
@@ -30,17 +33,42 @@ def write_precalcs_batch_writer(dynamodb_table: str, precalcs: List[Prediction])
             )
 
 
-def write_metadata(bucket: str, metadata_key: str, metadata: Metadata) -> None:
-    s3 = boto3.client("s3")
+def _write_metadata(bucket: str, key: str, obj: Metadata) -> None:
+    s3_client.put_object(Bucket=bucket, Key=key, Body=json.dumps(obj.json()))
 
-    metadata_json = {
-        "model_id": metadata.model_id,
-        "preds_in_store": metadata.preds_in_store,
-        "total_unique_preds": metadata.total_unique_preds,
-        "preds_last_updated": metadata.preds_last_updated,
-        "pipeline_latest_start_time": metadata.pipeline_latest_start_time,
-        "pipeline_latest_duration": metadata.pipeline_latest_duration,
-        "pipeline_meta_s3_uri": metadata.pipeline_meta_s3_uri,
-    }
 
-    s3.put_object(Bucket=bucket, Key=metadata_key, Body=json.dumps(metadata_json))
+def write_metadata_end(
+    table_name: str, bucket: str, model_id: str, end_time: int, metadata_key: str, s3_uri: str
+) -> None:
+    metadata = get_metadata(bucket, metadata_key)
+
+    model_id_search = dynamodb.scan(
+        TableName=table_name,
+        FilterExpression="SK=:model_id",
+        ExpressionAttributeValues={":model_id": {"S": f"MODELID#{model_id}"}},
+        Select="COUNT",
+    )
+    if model_id_search["Count"] > 0:
+        metadata.preds_in_store = True
+        metadata.total_unique_preds = model_id_search["Count"]
+
+    metadata.preds_last_updated = end_time
+
+    # this assumes that the pipeline start time is the current run's and has been written to metadata already...
+    metadata.pipeline_latest_duration = metadata.preds_last_updated - metadata.pipeline_latest_start_time
+
+    metadata.pipeline_meta_s3_uri = s3_uri
+
+    _write_metadata(bucket, metadata_key, metadata)
+
+
+def write_metadata_start(bucket: str, start_time: int, metadata_key: str) -> None:
+    try:
+        metadata = get_metadata(bucket, metadata_key)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchKey":
+            metadata = Metadata()
+
+    metadata.pipeline_latest_start_time = start_time
+
+    _write_metadata(bucket, metadata_key, metadata)

--- a/scripts/generate_predictions.py
+++ b/scripts/generate_predictions.py
@@ -24,11 +24,12 @@ def read_input_from_file(path_to_input: str = "reference_library.csv") -> List[s
 if __name__ == "__main__":
     input_path = sys.argv[1]
     output_path = sys.argv[2] if len(sys.argv) > 2 else "prediction_output.csv"
+    model_id = sys.argv[3] if len(sys.argv) > 3 else EXAMPLE_MODEL_ID
 
     input_items = read_input_from_file(input_path)
 
-    with ErsiliaModel(EXAMPLE_MODEL_ID) as mdl:
-        logger.info(f"Fetched model {EXAMPLE_MODEL_ID}")
+    with ErsiliaModel(model_id) as mdl:
+        logger.info(f"Fetched model {model_id}")
 
         start = time.time()
         predictions = mdl.run(input_items, output="pandas")

--- a/scripts/write_metadata_to_s3.py
+++ b/scripts/write_metadata_to_s3.py
@@ -1,0 +1,42 @@
+import argparse
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from precalculator.read import get_metadata
+from precalculator.write import write_metadata
+
+dotenv_path = Path("./config/stack.env")  # relative to root of git repo
+load_dotenv(dotenv_path=dotenv_path)
+
+BUCKET_NAME = str(os.getenv("S3_BUCKET_NAME"))
+DYNAMODB_TABLE_NAME = str(os.getenv("DYNAMODB_TABLE_NAME"))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="Metadata", description="Write Ersilia model inference pipeline metadata to S3"
+    )
+
+    parser.add_argument("model_id", help="ID of the Ersilia model for which predictions are to be written", type=str)
+
+    parser.add_argument("pipeline_timestamps", help="Timestamps of the pipeline run", type=str)
+
+    return parser
+
+
+def get_metadata_s3_uri(metadata_key: str) -> str:
+    return os.path.join("s3://", BUCKET_NAME, metadata_key)
+
+
+if __name__ == "__main__":
+    parser = build_parser()
+    args = parser.parse_args()
+
+    metadata_key = f"meta/{args.model_id}.json"
+    s3_uri = get_metadata_s3_uri(metadata_key)
+
+    metadata = get_metadata(DYNAMODB_TABLE_NAME, args.model_id, args.pipeline_timestamps, s3_uri)
+
+    write_metadata(BUCKET_NAME, metadata_key, metadata)

--- a/scripts/write_metadata_to_s3.py
+++ b/scripts/write_metadata_to_s3.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-from precalculator.write import write_metadata_end, write_metadata_start
+from precalculator.read import get_metadata
+from precalculator.write import write_metadata
 
 dotenv_path = Path("./config/stack.env")  # relative to root of git repo
 load_dotenv(dotenv_path=dotenv_path)
@@ -20,11 +21,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     parser.add_argument("model_id", help="ID of the Ersilia model for which predictions are to be written", type=str)
 
-    parser.add_argument(
-        "--pipeline_start", help="Timestamp for when the pipeline run started", type=int, required=False
-    )
+    parser.add_argument("pipeline_start", help="Timestamp for when the pipeline run started", type=int)
 
-    parser.add_argument("--pipeline_end", help="Timestamp for when the pipeline run ended", type=int, required=False)
+    parser.add_argument("pipeline_end", help="Timestamp for when the pipeline run ended", type=int)
 
     return parser
 
@@ -40,7 +39,8 @@ if __name__ == "__main__":
     metadata_key = f"meta/{args.model_id}.json"
     s3_uri = get_metadata_s3_uri(metadata_key)
 
-    if args.pipeline_start:
-        write_metadata_start(BUCKET_NAME, args.pipeline_start, metadata_key)
-    elif args.pipeline_end:
-        write_metadata_end(DYNAMODB_TABLE_NAME, BUCKET_NAME, args.model_id, args.pipeline_end, metadata_key, s3_uri)
+    metadata = get_metadata(
+        BUCKET_NAME, DYNAMODB_TABLE_NAME, metadata_key, s3_uri, args.model_id, args.pipeline_start, args.pipeline_end
+    )
+
+    write_metadata(BUCKET_NAME, metadata_key, metadata)

--- a/scripts/write_metadata_to_s3.py
+++ b/scripts/write_metadata_to_s3.py
@@ -4,8 +4,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-from precalculator.read import get_metadata
-from precalculator.write import write_metadata
+from precalculator.write import write_metadata_end, write_metadata_start
 
 dotenv_path = Path("./config/stack.env")  # relative to root of git repo
 load_dotenv(dotenv_path=dotenv_path)
@@ -21,7 +20,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     parser.add_argument("model_id", help="ID of the Ersilia model for which predictions are to be written", type=str)
 
-    parser.add_argument("pipeline_timestamps", help="Timestamps of the pipeline run", type=str)
+    parser.add_argument(
+        "--pipeline_start", help="Timestamp for when the pipeline run started", type=int, required=False
+    )
+
+    parser.add_argument("--pipeline_end", help="Timestamp for when the pipeline run ended", type=int, required=False)
 
     return parser
 
@@ -37,6 +40,7 @@ if __name__ == "__main__":
     metadata_key = f"meta/{args.model_id}.json"
     s3_uri = get_metadata_s3_uri(metadata_key)
 
-    metadata = get_metadata(DYNAMODB_TABLE_NAME, args.model_id, args.pipeline_timestamps, s3_uri)
-
-    write_metadata(BUCKET_NAME, metadata_key, metadata)
+    if args.pipeline_start:
+        write_metadata_start(BUCKET_NAME, args.pipeline_start, metadata_key)
+    elif args.pipeline_end:
+        write_metadata_end(DYNAMODB_TABLE_NAME, BUCKET_NAME, args.model_id, args.pipeline_end, metadata_key, s3_uri)

--- a/scripts/write_predictions_to_dynamodb.py
+++ b/scripts/write_predictions_to_dynamodb.py
@@ -13,7 +13,7 @@ dotenv_path = Path("./config/stack.env")  # relative to root of git repo
 load_dotenv(dotenv_path=dotenv_path)
 
 BUCKET_NAME = str(os.getenv("S3_BUCKET_NAME"))
-PREDICTIONS_S3_PREFIX = os.path.join(BUCKET_NAME, "out")
+PREDICTIONS_S3_PREFIX = os.path.join("s3://", BUCKET_NAME, "out")
 
 DYNAMODB_TABLE_NAME = str(os.getenv("DYNAMODB_TABLE_NAME"))
 


### PR DESCRIPTION
This is a working PR for collecting metadata and storing it into S3 (https://github.com/ersilia-os/model-inference-pipeline/issues/14).

I've tested it locally via the CLI which successfully uploads the metadata in the format described in the issue above.

**Observations**
1. The current workflows expect the number of inputs to be greater than 50, in other cases:
 - Less than 50: The number of workers is fixed to 50 so not all workers will receive inputs (since the input file is partitioned in less than 50 ways, according to [this run](https://github.com/ersilia-os/model-inference-pipeline/actions/runs/9059566256/job/24887435620#step:7:37)) and will fail. If any one of the worker fails, the whole run fails and no predictions are uploaded to DynamoDB.
 - Equal to 50: The splitting by numerator results in the first worker failing because (from what I can tell and based on the logs of [this run](https://github.com/ersilia-os/model-inference-pipeline/actions/runs/9073365703/job/24930332369#step:13:92)) it only received the header of the input file ("smiles") and no actual inputs. Once the first worker fails, the whole run fails and predictions are uploaded to S3 depending on whether or not each worker finished inference and executed to the S3 copy step by the time the first worker fails. It seems hard/impossible to predict which workers will get to that stage and which won't... regardless, no predictions are uploaded to DynamoDB.
- Conclusion: I think the workflows themselves could be modified to account for small batches of inputs to be processed so that metadata can be generated for the whole reference library as well as for subsets of it when, down the line, humans opt into prediction collection via the CLI (where I don't imagine they'll always be running against the whole library)... this could be done by making the number of workers dependent on the number of inputs, or otherwise

2. I created a new workflow to run the pipeline on a subset of the reference library to make it easier to test everything end-to-end but I can't check if this works since it requires the workflow to be merged into main first... though if the current workflows can be adapted to a variable number of inputs, this won't be needed. For now, I've added copies of the reference library into S3 and a variable in the existing workflow to allow selection of which subset (if any) to run inference on.

3. I haven't tested this PR end-to-end via GitHub Actions yet since that may require merging into main (the serving part of the pipeline uses the workflow on main which doesn't have the S3 URI fix on the feature branch - see [this run](https://github.com/ersilia-os/model-inference-pipeline/actions/runs/9073816601/job/24931519528#step:6:29) for the URI error and [this run](https://github.com/ersilia-os/model-inference-pipeline/actions/runs/9077641295) showing the logs from the most recent run on the feature branch.

@kartikey-vyas Let me know if you have any questions, suggestions etc., happy to meet before Thursday to discuss.