### PR TITLE
Move metadata logging out of parallel workers

### DIFF
--- a/.github/workflows/log-metadata.yml
+++ b/.github/workflows/log-metadata.yml
@@ -1,0 +1,39 @@
+name: Log metadata
+
+on:
+  workflow_call:
+    inputs:
+      model:
+        required: true
+        type: string
+      start-time:
+        required: true
+        type: string
+
+jobs:
+    log-metadata:
+      runs-on: ubuntu-latest
+      steps:
+        - name: checkout repo content
+          uses: actions/checkout@v4 # checkout repo content
+
+        - name: setup python
+          uses: actions/setup-python@v4 # setup python environment
+          with:
+            python-version: '3.10'
+
+        - name: configure AWS credentials
+          uses: aws-actions/configure-aws-credentials@master
+          with:
+             aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+             aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+             aws-region: eu-central-1
+
+        - name: install venv
+          run: |
+            make install-prod
+
+        - name: write metadata to s3
+          run: |
+            end_time=$(date +%s)
+            .venv/bin/python3 scripts/write_metadata_to_s3.py ${{ inputs.model }} ${{ inputs.start_time }} $end_time

--- a/.github/workflows/predict-serve-sample.yml
+++ b/.github/workflows/predict-serve-sample.yml
@@ -32,10 +32,6 @@ jobs:
                     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
                     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                     aws-region: eu-central-1
-            
-            -   name: Save pipeline start time
-                run: |
-                    echo "$(date +%s)" > meta.txt
 
             -   name: Get input library
                 run: |

--- a/.github/workflows/serve-parallel.yml
+++ b/.github/workflows/serve-parallel.yml
@@ -36,6 +36,12 @@ jobs:
     with:
       model: ${{ github.event.client_payload.model-id }}
       sha: ${{ github.event.client_payload.sha }}
-      start_time: ${{ github.event.client_payload.start_time }}
       partition: ${{ matrix.partition }}
+    secrets: inherit
+
+  log-metadata:
+    uses: ./.github/workflows/log-metadata.yml
+    with:
+      model: ${{ github.event.client_payload.model-id }}
+      start_time: ${{ github.event.client_payload.start_time }}
     secrets: inherit

--- a/.github/workflows/serve.yml
+++ b/.github/workflows/serve.yml
@@ -9,9 +9,6 @@ on:
       sha:
         required: true
         type: string
-      start_time:
-        required: true
-        type: string
       partition:
         required: true
         type: number
@@ -22,9 +19,6 @@ on:
         required: true
         type: string
       sha:
-        required: true
-        type: string
-      start_time:
         required: true
         type: string
       partition:
@@ -57,8 +51,3 @@ jobs:
       - name: serve predictions to dynamodb
         run: |
           .venv/bin/python3 scripts/write_predictions_to_dynamodb.py ${{ inputs.model }} ${{ inputs.sha }} ${{ inputs.partition }}
-
-      - name: write metadata to s3
-        run: |
-          end_time=$(date +%s)
-          .venv/bin/python3 scripts/write_metadata_to_s3.py ${{ inputs.model }} ${{ inputs.start_time }} $end_time

--- a/precalculator/read.py
+++ b/precalculator/read.py
@@ -49,7 +49,8 @@ def get_metadata(
 ) -> Metadata:
     try:
         metadata_obj = s3_client.get_object(Bucket=bucket, Key=metadata_key)
-        metadata_json = json.loads(metadata_obj["Body"].read().decode("utf-8"))
+        metadata_string = metadata_obj["Body"].read().decode("utf-8")
+        metadata_json = json.loads(metadata_string)
         metadata = Metadata(**metadata_json)
     except ClientError as e:
         if e.response["Error"]["Code"] == "NoSuchKey":


### PR DESCRIPTION
Moving metadata logging outside of the workers will keep all the metadata (particularly the end time, which was being generated by each worker) consistent and accurate, since I was seeing that each worker would try to log its own end time.

@kartikey-vyas Let me know if you have any questions, suggestions etc.