### PR TITLE
Read predictions from cloud via Ersilia CLI

### DIFF
--- a/config/settings.env
+++ b/config/settings.env
@@ -1,12 +1,10 @@
 S3_BUCKET_NAME=precalculations-bucket
+S3_UPLOAD_PREFIX=uploads
 S3_INPUT_PREFIX=in/test
 S3_OUTPUT_PREFIX=out
-S3_UPLOAD_PREFIX=uploads
 
 ATHENA_DATABASE=precalcs_test
 ATHENA_PREDICTION_TABLE=predictions
 ATHENA_REQUEST_TABLE=requests
 
-API_HANDLER_LAMBDA_NAME=precalc-api-handler
 API_ENDPOINT_NAME=precalc-predictions-endpoint
-API_KEY_NAME=ersilia-precalc-dev-key

--- a/infra/precalculator/cdk.json
+++ b/infra/precalculator/cdk.json
@@ -1,5 +1,5 @@
 {
-  "app": "python3 app.py",
+  "app": "python app.py",
   "watch": {
     "include": [
       "**"
@@ -57,6 +57,14 @@
     "@aws-cdk/aws-rds:auroraClusterChangeScopeOfInstanceParameterGroupWithEachParameters": true,
     "@aws-cdk/aws-appsync:useArnForSourceApiAssociationIdentifier": true,
     "@aws-cdk/aws-rds:preventRenderingDeprecatedCredentials": true,
-    "@aws-cdk/aws-codepipeline-actions:useNewDefaultBranchForCodeCommitSource": true
+    "@aws-cdk/aws-codepipeline-actions:useNewDefaultBranchForCodeCommitSource": true,
+    "@aws-cdk/aws-cloudwatch-actions:changeLambdaPermissionLogicalIdForLambdaAction": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeysDefaultValueToFalse": true,
+    "@aws-cdk/aws-codepipeline:defaultPipelineTypeToV2": true,
+    "@aws-cdk/aws-kms:reduceCrossAccountRegionPolicyScope": true,
+    "@aws-cdk/aws-eks:nodegroupNameAttribute": true,
+    "@aws-cdk/aws-ec2:ebsDefaultGp3Volume": true,
+    "@aws-cdk/aws-ecs:removeDefaultDeploymentAlarm": true,
+    "@aws-cdk/custom-resources:logApiResponseDataPropertyTrueDefault": false
   }
 }

--- a/infra/precalculator/lambda/fetch_predictions.py
+++ b/infra/precalculator/lambda/fetch_predictions.py
@@ -13,7 +13,7 @@ def handler(event: dict, context: dict) -> dict:
         model_id (str): _description_
 
     Returns:
-        pd.DataFrame: _description_
+        pd.DataFrame: predictions
     """
     request_id = event["queryStringParameters"]["requestid"]
     model_id = event["queryStringParameters"]["modelid"]

--- a/infra/precalculator/lambda/fetch_predictions.py
+++ b/infra/precalculator/lambda/fetch_predictions.py
@@ -1,0 +1,175 @@
+import json
+import boto3
+import logging
+import os
+import sys
+import pandas as pd
+import awswrangler as wr
+
+
+def lambda_handler(event: dict, context: dict) -> dict:
+    """Fetch predictions
+
+    Args:
+        request_id (str): _description_
+        model_id (str): _description_
+
+    Returns:
+        pd.DataFrame: _description_
+    """
+    request_id = event["queryStringParameters"]["requestid"]
+    model_id = event["queryStringParameters"]["modelid"]
+
+    config = None  # TODO: parametrise file paths via config file
+    fetcher = PredictionFetcher(config, request_id, model_id)
+    path_to_input = fetcher.get_s3_input_location()
+    output_s3_url = fetcher.fetch(path_to_input)
+    return {"statusCode": 200, "body": output_s3_url}
+
+
+# TODO: merge PredictionFetchers and create deployment
+# package using model-inference-pipeline repo
+class PredictionFetcher:
+    def __init__(self, config, request_id: str, model_id: str, dev: bool = False):
+        self.config = config
+        self.request_id = request_id
+        self.model_id = model_id
+        self.dev = dev
+
+        self.logger = logging.getLogger("PredictionFetcher")
+        self.logger.setLevel(logging.INFO)
+
+        if self.dev:
+            logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+            logging.getLogger("botocore").setLevel(logging.WARNING)
+
+    def get_s3_input_location(self) -> str:
+        return os.path.join("s3://", "precalculations-bucket", "uploads", self.model_id, f"{self.request_id}.csv")
+
+    def fetch(self, path_to_input: str):
+        logger = self.logger
+
+        logger.info("reading and formatting input data")
+        input_df = self._read_input_data(path_to_input)
+        logger.info(input_df.head())
+
+        logger.info("writing input to athena")
+        self._write_inputs_s3(input_df)
+
+        logger.info("fetching outputs from athena")
+        output_df = self._read_predictions_from_s3()
+
+        logger.info("storing outputs into s3")
+        self._write_outputs_s3(output_df)
+
+        logger.info("returning presigned url")
+        output_presigned_url = self._get_output_presigned_url()
+
+        return output_presigned_url
+
+    def _read_input_data(self, path_to_input: str):
+        """Reads input CSV from user and processes it for writing to the data lake
+
+        Args:
+            path_to_input (str): location of input CSV
+
+        Returns:
+            pd.DataFrame: formatted data frame
+        """
+
+        # expect just a list of SMILEs with no header
+        df = wr.s3.read_csv(path=path_to_input, header=None)
+        df.rename(columns={0: "smiles"}, inplace=True)
+
+        # TODO: validate smiles?
+        ## for example -----------------------------------------
+        # cid = CompoundIdentifier()
+        # valid_smiles = df.apply(lambda x: cid._is_smiles(x))
+
+        # df_invalid = df[~valid_smiles]
+        # # generate invalid request summary
+
+        # df = df[valid_smiles]
+        # ------------------------------------------------------
+
+        df["request_id"] = self.request_id
+
+        return df[["smiles", "request_id"]]
+
+    def _write_inputs_s3(self, input_df) -> None:
+        # TODO: deduplicate repeated inputs
+        wr.s3.to_parquet(
+            df=input_df,
+            path=os.path.join(
+                "s3://",
+                "precalculations-bucket",
+                "in/test",
+            ),
+            dataset=True,
+            database="precalcs_test",
+            table="requests",
+            partition_cols=["request_id"],
+        )
+
+    def _read_predictions_from_s3(self):
+        # TODO: remove DISTINCT after inputs have been deduplicated
+        query = f"""
+            with request as (
+                select distinct
+                    *
+                from
+                    requests
+                where
+                    request_id = '{self.request_id}'
+            )
+            select distinct
+                p.model_id,
+                p.input_key,
+                p.smiles,
+                p.output
+            from
+                predictions p
+                left join request r
+                    on p.smiles = r.smiles
+            where
+                p.model_id = '{self.model_id}'
+        """
+
+        df_out = wr.athena.read_sql_query(query, database="precalcs_test")
+
+        return df_out
+
+    def _write_outputs_s3(self, output_df):
+        """Writes outputs to S3
+
+        Args:
+            output_df (pd.DataFrame)
+
+        Returns:
+            pd.DataFrame: formatted data frame
+        """
+        wr.s3.to_csv(
+            df=output_df,
+            path=os.path.join("s3://", "precalculations-bucket", "out", f"{self.model_id}", f"{self.request_id}.csv"),
+            index=False,
+        )
+
+    def _get_output_presigned_url(self):
+        """Writes outputs to S3
+
+        Args:
+            None
+
+        Returns:
+            presigned_url (str): Pre-signed URL to download precalculations as csv
+        """
+        s3_client = boto3.client("s3")
+        try:
+            presigned_url = s3_client.generate_presigned_url(
+                "get_object",
+                Params={"Bucket": "precalculations-bucket", "Key": f"out/{self.model_id}/{self.request_id}.csv"},
+                ExpiresIn=3600,
+            )
+            return presigned_url
+        except Exception as e:
+            self.logger.info("Error generating presigned URL: ", e)

--- a/infra/precalculator/lambda/generate_presigned_url.py
+++ b/infra/precalculator/lambda/generate_presigned_url.py
@@ -1,0 +1,15 @@
+import json
+import boto3
+from config.app import DataLakeConfig
+
+
+def lambda_handler(event, context):
+    model_id = event["queryStringParameters"]["modelid"]
+    request_id = event["queryStringParameters"]["requestid"]
+    # Generate pre-signed URL for uploading
+    s3_client = boto3.client("s3")
+    response = s3_client.generate_presigned_post(
+        "precalculations-bucket", f"uploads/{model_id}/{request_id}.csv", ExpiresIn=3600
+    )
+
+    return {"statusCode": 200, "body": json.dumps(response)}

--- a/infra/precalculator/lambda/generate_presigned_url.py
+++ b/infra/precalculator/lambda/generate_presigned_url.py
@@ -1,15 +1,17 @@
 import json
+import os
 import boto3
-from config.app import DataLakeConfig
 
 
-def lambda_handler(event, context):
+def handler(event, context):
     model_id = event["queryStringParameters"]["modelid"]
     request_id = event["queryStringParameters"]["requestid"]
     # Generate pre-signed URL for uploading
     s3_client = boto3.client("s3")
     response = s3_client.generate_presigned_post(
-        "precalculations-bucket", f"uploads/{model_id}/{request_id}.csv", ExpiresIn=3600
+        os.environ.get("BUCKET_NAME"),
+        f"{os.environ.get('S3_UPLOAD_PREFIX')}/{model_id}/{request_id}.csv",
+        ExpiresIn=3600,
     )
 
-    return {"statusCode": 200, "body": json.dumps(response)}
+    return {"statusCode": 200, "headers": {"Content-Type": "application/json"}, "body": json.dumps(response)}

--- a/infra/precalculator/lambda/generate_presigned_url.py
+++ b/infra/precalculator/lambda/generate_presigned_url.py
@@ -4,6 +4,15 @@ import boto3
 
 
 def handler(event, context):
+    """Create presigned URL for uploading CSV file to S3
+
+    Args:
+        event (dict): _description_
+        context (dict): _description_
+
+    Returns:
+        response (str): pre-signed url
+    """
     model_id = event["queryStringParameters"]["modelid"]
     request_id = event["queryStringParameters"]["requestid"]
     # Generate pre-signed URL for uploading

--- a/infra/precalculator/lambda/get_model.py
+++ b/infra/precalculator/lambda/get_model.py
@@ -10,7 +10,7 @@ def handler(event: dict, context: dict) -> bool:
         context (dict): _description_
 
     Returns:
-        has_model (bool): _description_
+        has_model (bool): whether or not precalculations for the model exist
     """
     model_id = event["queryStringParameters"]["modelid"]
     glue_client = boto3.client("glue")

--- a/infra/precalculator/lambda/get_model.py
+++ b/infra/precalculator/lambda/get_model.py
@@ -1,0 +1,29 @@
+import json
+import boto3
+from config.app import DataLakeConfig
+
+
+def handler(event: dict, context: dict) -> bool:
+    """Check model exists
+
+    Args:
+        event (dict): _description_
+        context (dict): _description_
+
+    Returns:
+        has_model (bool): _description_
+    """
+    model_id = event["queryStringParameters"]["modelid"]
+    glue_client = boto3.client("glue")
+    has_model = False
+
+    try:
+        response = glue_client.get_partition(
+            DatabaseName="precalcs_test", TableName="predictions", PartitionValues=[model_id]
+        )
+        has_model = len(response["Partition"]["Values"]) > 0
+    except glue_client.exceptions.EntityNotFoundException:
+        print(f"Model {model_id} not found")
+    except Exception as e:
+        print(f"An error occurred: {str(e)}")
+    return {"statusCode": 200, "body": has_model}

--- a/infra/precalculator/lambda/get_model.py
+++ b/infra/precalculator/lambda/get_model.py
@@ -1,6 +1,5 @@
-import json
+import os
 import boto3
-from config.app import DataLakeConfig
 
 
 def handler(event: dict, context: dict) -> bool:
@@ -19,11 +18,13 @@ def handler(event: dict, context: dict) -> bool:
 
     try:
         response = glue_client.get_partition(
-            DatabaseName="precalcs_test", TableName="predictions", PartitionValues=[model_id]
+            DatabaseName=os.environ.get("ATHENA_DATABASE"),
+            TableName=os.environ.get("ATHENA_PREDICTION_TABLE"),
+            PartitionValues=[model_id],
         )
         has_model = len(response["Partition"]["Values"]) > 0
     except glue_client.exceptions.EntityNotFoundException:
         print(f"Model {model_id} not found")
     except Exception as e:
         print(f"An error occurred: {str(e)}")
-    return {"statusCode": 200, "body": has_model}
+    return {"statusCode": 200, "headers": {"Content-Type": "application/json"}, "body": has_model}

--- a/infra/precalculator/precalculator/precalculator_stack.py
+++ b/infra/precalculator/precalculator/precalculator_stack.py
@@ -218,7 +218,7 @@ class PrecalculatorStack(Stack):
             "apigateway",
             principal=iam.ServicePrincipal("apigateway.amazonaws.com"),
             action="lambda:InvokeFunction",
-            source_arn=f"arn:aws:execute-api:{self.region}:{self.account}:{api.arn_for_execute_api()}/*/POST/precalculations/upload-destination",
+            source_arn=f"arn:aws:execute-api:{self.region}:{self.account}:{api.arn_for_execute_api()}/*/POST/precalculations/predictions",
         )
 
         # GET /precalculations/upload-destination
@@ -236,7 +236,7 @@ class PrecalculatorStack(Stack):
             "apigateway",
             principal=iam.ServicePrincipal("apigateway.amazonaws.com"),
             action="lambda:InvokeFunction",
-            source_arn=f"arn:aws:execute-api:{self.region}:{self.account}:{api.arn_for_execute_api()}/*/POST/precalculations/predictions",
+            source_arn=f"arn:aws:execute-api:{self.region}:{self.account}:{api.arn_for_execute_api()}/*/GET/precalculations/upload-destination",
         )
 
         ### Athena ###

--- a/infra/precalculator/precalculator/precalculator_stack.py
+++ b/infra/precalculator/precalculator/precalculator_stack.py
@@ -1,80 +1,113 @@
+from aws_cdk import Duration, RemovalPolicy, Stack, aws_apigateway as apigateway, aws_lambda as lambda_, aws_s3 as s3
+from constructs import Construct
+
 import os
 from pathlib import Path
-
-from aws_cdk import (
-    Duration,
-    RemovalPolicy,
-    # Duration,
-    Stack,
-)
-from aws_cdk import (
-    aws_apigateway as apigateway,
-)
-from aws_cdk import (
-    aws_lambda as lambda_,
-)
-from aws_cdk import (
-    aws_s3 as s3,
-)
-from constructs import Construct
 from dotenv import load_dotenv
 
-dotenv_path = Path("../../config/stack.env")
+dotenv_path = Path("../../config/settings.env")
 load_dotenv(dotenv_path=dotenv_path)
 
 BUCKET_NAME = str(os.getenv("S3_BUCKET_NAME"))
+S3_UPLOAD_PREFIX = str(os.getenv("S3_UPLOAD_PREFIX"))
+S3_INPUT_PREFIX = str(os.getenv("S3_INPUT_PREFIX"))
+S3_OUTPUT_PREFIX = str(os.getenv("S3_OUTPUT_PREFIX"))
 HANDLER_NAME = str(os.getenv("API_HANDLER_LAMBDA_NAME"))
 ENDPOINT_NAME = str(os.getenv("API_ENDPOINT_NAME"))
-API_KEY_NAME = str(os.getenv("API_KEY_NAME"))
+ATHENA_DATABASE = str(os.getenv("ATHENA_DATABASE"))
+ATHENA_PREDICTION_TABLE = str(os.getenv("ATHENA_PREDICTION_TABLE"))
+ATHENA_REQUEST_TABLE = str(os.getenv("ATHENA_REQUEST_TABLE"))
 
 
 class PrecalculatorStack(Stack):
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
-        # S3 Bucket
-        bucket = s3.Bucket(
-            self,
-            BUCKET_NAME,
-            bucket_name=BUCKET_NAME,
-            public_read_access=False,
-            versioned=False,
-        )
+        ### S3 ###
+        bucket = s3.Bucket(self, id=BUCKET_NAME, bucket_name=BUCKET_NAME, public_read_access=False, versioned=False)
 
-        # API Lambda
-        api_handler = lambda_.Function(
+        ### Lambda ###
+        get_model = lambda_.Function(
             self,
-            HANDLER_NAME,
-            function_name=HANDLER_NAME,
-            runtime=lambda_.Runtime.PYTHON_3_10,
+            id="get_model",
+            function_name="get_model",
+            runtime=lambda_.Runtime.PYTHON_3_12,
             code=lambda_.Code.from_asset("lambda"),
-            handler="api_handler.handler",
-            environment={"BUCKET_NAME": bucket.bucket_name},
+            handler="get_model.handler",
+            environment={"ATHENA_DATABASE": ATHENA_DATABASE, "ATHENA_PREDICTION_TABLE": ATHENA_PREDICTION_TABLE},
             memory_size=512,
             timeout=Duration.seconds(30),
         )
 
-        # grant permissions for lambda to write to bucket
-        bucket.grant_read_write(api_handler)
+        generate_presigned_url = lambda_.Function(
+            self,
+            id="generate_presigned_url",
+            function_name="generate_presigned_url",
+            runtime=lambda_.Runtime.PYTHON_3_12,
+            code=lambda_.Code.from_asset("lambda"),
+            handler="generate_presigned_url.handler",
+            environment={"BUCKET_NAME": BUCKET_NAME, "S3_UPLOAD_PREFIX": S3_UPLOAD_PREFIX},
+            memory_size=512,
+            timeout=Duration.seconds(30),
+        )
 
-        # API Gateway
+        # TODO: add aws-swk-pandas 3.9.1 as a layer via CDK: https://github.com/aws/aws-sdk-pandas/releases
+        fetch_predictions = lambda_.Function(
+            self,
+            id="fetch_predictions",
+            function_name="fetch_predictions",
+            runtime=lambda_.Runtime.PYTHON_3_12,
+            code=lambda_.Code.from_asset("lambda"),
+            handler="fetch_predictions.handler",
+            environment={
+                "BUCKET_NAME": BUCKET_NAME,
+                "S3_UPLOAD_PREFIX": S3_UPLOAD_PREFIX,
+                "S3_INPUT_PREFIX": S3_INPUT_PREFIX,
+                "S3_OUTPUT_PREFIX": S3_OUTPUT_PREFIX,
+                "ATHENA_DATABASE": ATHENA_DATABASE,
+                "ATHENA_REQUEST_TABLE": ATHENA_REQUEST_TABLE,
+            },
+            memory_size=512,
+            timeout=Duration.seconds(120),
+        )
+
+        ### API Gateway ###
         api = apigateway.LambdaRestApi(
             self,
-            ENDPOINT_NAME,
+            id=ENDPOINT_NAME,
+            # handler=api_handler
             description="API Endpoint for Precalculations created via CDK",
-            handler=api_handler,
-            # regional endpoint, don't use cloudfront
             endpoint_configuration=apigateway.EndpointConfiguration(types=[apigateway.EndpointType.REGIONAL]),
             deploy=True,
             deploy_options=apigateway.StageOptions(stage_name="dev", description="DEV deployment of Precalcs Endpoint"),
             proxy=False,
         )
-
-        predictions = api.root.add_resource("predictions")
-        predictions.add_method("GET", api_key_required=True)
-
-        api.add_api_key(
-            API_KEY_NAME,
-            api_key_name=API_KEY_NAME,
-            description="Default API Key for Precalculations endpoint created via CDK",
+        precalculations = api.root.add_resource("precalculations")
+        model = precalculations.add_resource("model")
+        # GET /precalculations/model
+        model.add_method(
+            "GET",
+            apigateway.LambdaIntegration(get_model),
+            request_parameters={"method.request.querystring.modelid": True},
+        )
+        predictions = precalculations.add_resource("predictions")
+        # POST /precalculations/predictions
+        predictions.add_method(
+            "POST",
+            apigateway.LambdaIntegration(generate_presigned_url),
+            request_parameters={
+                "method.request.querystring.modelid": True,
+                "method.request.querystring.requestid": True,
+                "method.request.querystring.userid": False,
+            },
+        )
+        upload_destination = precalculations.add_resource("upload-destination")
+        # GET /precalculations/upload-destination
+        upload_destination.add_method(
+            "GET",
+            apigateway.LambdaIntegration(fetch_predictions),
+            request_parameters={
+                "method.request.querystring.modelid": True,
+                "method.request.querystring.requestid": True,
+            },
         )

--- a/infra/precalculator/precalculator/precalculator_stack.py
+++ b/infra/precalculator/precalculator/precalculator_stack.py
@@ -1,4 +1,14 @@
-from aws_cdk import Duration, RemovalPolicy, Stack, aws_apigateway as apigateway, aws_lambda as lambda_, aws_s3 as s3
+from aws_cdk import (
+    Duration,
+    Stack,
+    aws_lambda as lambda_,
+    aws_apigateway as apigateway,
+    aws_athena as athena,
+    aws_glue as glue,
+    aws_s3 as s3,
+    aws_iam as iam,
+)
+
 from constructs import Construct
 
 import os
@@ -23,8 +33,92 @@ class PrecalculatorStack(Stack):
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
-        ### S3 ###
-        bucket = s3.Bucket(self, id=BUCKET_NAME, bucket_name=BUCKET_NAME, public_read_access=False, versioned=False)
+        ### IAM ###
+        glue_role = iam.Role(
+            self,
+            id="glue-role",
+            assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name("service-role/AWSLambdaBasicExecutionRole"),
+                iam.ManagedPolicy.from_aws_managed_policy_name("service-role/AWSLambdaVPCAccessExecutionRole"),
+            ],
+        )
+
+        glue_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "s3:Abort*",
+                    "s3:DeleteObject*",
+                    "s3:GetBucket*",
+                    "s3:GetObject*",
+                    "s3:List*",
+                    "s3:PutObject",
+                    "s3:PutObjectLegalHold",
+                    "s3:PutObjectRetention",
+                    "s3:PutObjectTagging",
+                    "s3:PutObjectVersionTagging",
+                ],
+                resources=[f"arn:aws:s3:::{BUCKET_NAME}", f"arn:aws:s3:::{BUCKET_NAME}/*"],
+                effect=iam.Effect.ALLOW,
+            )
+        )
+
+        glue_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "s3:ListBucket",
+                    "s3:GetBucketLocation",
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:PutObjectLegalHold",
+                    "s3:PutObjectRetention",
+                    "s3:PutObjectTagging",
+                    "s3:PutObjectVersionTagging",
+                ],
+                resources=[
+                    f"arn:aws:s3:::aws-athena-query-results-{self.region}-{self.account}",
+                    f"arn:aws:s3:::aws-athena-query-results-{self.region}-{self.account}/*",
+                ],
+                effect=iam.Effect.ALLOW,
+            )
+        )
+
+        glue_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "glue:BatchGetPartition",
+                    "glue:GetColumnStatisticsForPartition",
+                    "glue:GetPartition",
+                    "glue:GetPartitionIndexes",
+                    "glue:GetPartitions",
+                    "glue:GetTable",
+                    "glue:GetTables",
+                    "glue:CreateTable",
+                    "glue:BatchCreatePartition",
+                    "glue:CreatePartitionIndex",
+                    "glue:CreatePartition",
+                ],
+                resources=["*"],
+                effect=iam.Effect.ALLOW,
+            )
+        )
+
+        # allow deletion of temporary resources at a catalog, database, and table level
+        # (required for Lambdas to function properly)
+        glue_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["glue:DeleteTable"],
+                resources=[
+                    f"arn:aws:glue:{self.region}:{self.account}:{self.account}",
+                    f"arn:aws:glue:{self.region}:{self.account}:database/{ATHENA_DATABASE}",
+                    f"arn:aws:glue:{self.region}:{self.account}:table/{ATHENA_DATABASE}/temp_table*",
+                ],
+                effect=iam.Effect.ALLOW,
+            )
+        )
+
+        # TODO: restrict to only the necessary actions and resources
+        glue_role.add_to_policy(iam.PolicyStatement(actions=["athena:*"], resources=["*"], effect=iam.Effect.ALLOW))
 
         ### Lambda ###
         get_model = lambda_.Function(
@@ -37,6 +131,7 @@ class PrecalculatorStack(Stack):
             environment={"ATHENA_DATABASE": ATHENA_DATABASE, "ATHENA_PREDICTION_TABLE": ATHENA_PREDICTION_TABLE},
             memory_size=512,
             timeout=Duration.seconds(30),
+            role=glue_role,
         )
 
         generate_presigned_url = lambda_.Function(
@@ -49,9 +144,11 @@ class PrecalculatorStack(Stack):
             environment={"BUCKET_NAME": BUCKET_NAME, "S3_UPLOAD_PREFIX": S3_UPLOAD_PREFIX},
             memory_size=512,
             timeout=Duration.seconds(30),
+            role=glue_role,
         )
 
-        # TODO: add aws-swk-pandas 3.9.1 as a layer via CDK: https://github.com/aws/aws-sdk-pandas/releases
+        # TODO: add aws-swk-pandas 3.9.1 as a layer via CDK:
+        # https://github.com/aws/aws-sdk-pandas/releases/tag/3.9.1
         fetch_predictions = lambda_.Function(
             self,
             id="fetch_predictions",
@@ -69,29 +166,44 @@ class PrecalculatorStack(Stack):
             },
             memory_size=512,
             timeout=Duration.seconds(120),
+            role=glue_role,
         )
 
         ### API Gateway ###
-        api = apigateway.LambdaRestApi(
+
+        # NOTE: apigateway.LambdaRestApi is unsuitable for cases where
+        # the default integration (/) is not used as it requires a handler
+        # to be passed to handle all requests which this stack does not have
+        # or currently need. Instead, a standard RestApi is used and a Lambda
+        # is specified as the integration for each endpoint.
+        api = apigateway.RestApi(
             self,
             id=ENDPOINT_NAME,
-            # handler=api_handler
             description="API Endpoint for Precalculations created via CDK",
             endpoint_configuration=apigateway.EndpointConfiguration(types=[apigateway.EndpointType.REGIONAL]),
             deploy=True,
+            # TODO: create a stage for prod
             deploy_options=apigateway.StageOptions(stage_name="dev", description="DEV deployment of Precalcs Endpoint"),
-            proxy=False,
         )
+
+        # GET /precalculations/model
         precalculations = api.root.add_resource("precalculations")
         model = precalculations.add_resource("model")
-        # GET /precalculations/model
         model.add_method(
             "GET",
             apigateway.LambdaIntegration(get_model),
             request_parameters={"method.request.querystring.modelid": True},
         )
-        predictions = precalculations.add_resource("predictions")
+        # Allow API Gateway to invoke the Lambda
+        get_model.add_permission(
+            "apigateway",
+            principal=iam.ServicePrincipal("apigateway.amazonaws.com"),
+            action="lambda:InvokeFunction",
+            source_arn=f"arn:aws:execute-api:{self.region}:{self.account}:{api.arn_for_execute_api()}/*/GET/precalculations/model",
+        )
+
         # POST /precalculations/predictions
+        predictions = precalculations.add_resource("predictions")
         predictions.add_method(
             "POST",
             apigateway.LambdaIntegration(generate_presigned_url),
@@ -101,8 +213,16 @@ class PrecalculatorStack(Stack):
                 "method.request.querystring.userid": False,
             },
         )
-        upload_destination = precalculations.add_resource("upload-destination")
+        # Allow API Gateway to invoke the Lambda
+        fetch_predictions.add_permission(
+            "apigateway",
+            principal=iam.ServicePrincipal("apigateway.amazonaws.com"),
+            action="lambda:InvokeFunction",
+            source_arn=f"arn:aws:execute-api:{self.region}:{self.account}:{api.arn_for_execute_api()}/*/POST/precalculations/upload-destination",
+        )
+
         # GET /precalculations/upload-destination
+        upload_destination = precalculations.add_resource("upload-destination")
         upload_destination.add_method(
             "GET",
             apigateway.LambdaIntegration(fetch_predictions),
@@ -111,3 +231,90 @@ class PrecalculatorStack(Stack):
                 "method.request.querystring.requestid": True,
             },
         )
+        # Allow API Gateway to invoke the Lambda
+        generate_presigned_url.add_permission(
+            "apigateway",
+            principal=iam.ServicePrincipal("apigateway.amazonaws.com"),
+            action="lambda:InvokeFunction",
+            source_arn=f"arn:aws:execute-api:{self.region}:{self.account}:{api.arn_for_execute_api()}/*/POST/precalculations/predictions",
+        )
+
+        ### Athena ###
+        athena_workgroup = athena.CfnWorkGroup(
+            self,
+            id="precalculations",
+            name="precalculations",
+            state="ENABLED",
+            work_group_configuration=athena.CfnWorkGroup.WorkGroupConfigurationProperty(
+                result_configuration=athena.CfnWorkGroup.ResultConfigurationProperty(
+                    output_location=f"s3://{BUCKET_NAME}/aws-athena-query-results-{self.account}-{self.region}"
+                )
+            ),
+        )
+
+        ### Glue ###
+        glue_database = glue.CfnDatabase(
+            self,
+            id="precalculations",
+            catalog_id=self.account,
+            database_input=glue.CfnDatabase.DatabaseIdentifierProperty(database_name=ATHENA_DATABASE),
+        )
+
+        predictions_table = glue.CfnTable(
+            self,
+            catalog_id=self.account,
+            id=ATHENA_PREDICTION_TABLE,
+            database_name=glue_database.database_name,
+            table_input=glue.CfnTable.TableInputProperty(
+                name=ATHENA_PREDICTION_TABLE,
+                table_type="EXTERNAL_TABLE",
+                parameters={"classification": "parquet"},
+                partition_keys=[glue.CfnTable.ColumnProperty(name="model_id")],
+                storage_descriptor=glue.CfnTable.StorageDescriptorProperty(
+                    columns=[
+                        glue.CfnTable.ColumnProperty(name="input_key", type="string"),
+                        glue.CfnTable.ColumnProperty(name="smiles", type="string"),
+                        glue.CfnTable.ColumnProperty(name="output", type="string"),
+                        glue.CfnTable.ColumnProperty(name="model_id", type="string"),
+                    ],
+                    location=f"s3://{BUCKET_NAME}/{ATHENA_PREDICTION_TABLE}",
+                    input_format="org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
+                    output_format="org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
+                    serde_info=glue.CfnTable.SerdeInfoProperty(
+                        serialization_library="org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
+                        parameters={"serialization.format": "1"},
+                    ),
+                ),
+            ),
+        )
+
+        requests_table = glue.CfnTable(
+            self,
+            catalog_id=self.account,
+            id=ATHENA_REQUEST_TABLE,
+            database_name=glue_database.database_name,
+            table_input=glue.CfnTable.TableInputProperty(
+                name=ATHENA_REQUEST_TABLE,
+                table_type="EXTERNAL_TABLE",
+                parameters={"classification": "parquet"},
+                partition_keys=[glue.CfnTable.ColumnProperty(name="request_id")],
+                storage_descriptor=glue.CfnTable.StorageDescriptorProperty(
+                    columns=[
+                        glue.CfnTable.ColumnProperty(name="smiles", type="string"),
+                        glue.CfnTable.ColumnProperty(name="request_id", type="string"),
+                    ],
+                    location=f"s3://{BUCKET_NAME}/{S3_INPUT_PREFIX}",
+                    input_format="org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
+                    output_format="org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
+                    serde_info=glue.CfnTable.SerdeInfoProperty(
+                        serialization_library="org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
+                        parameters={"serialization.format": "1"},
+                    ),
+                ),
+            ),
+        )
+
+        ### S3 ###
+        bucket = s3.Bucket(self, id=BUCKET_NAME, bucket_name=BUCKET_NAME, public_read_access=False, versioned=False)
+        bucket.grant_read_write(athena_workgroup)
+        bucket.grant_read_write(glue_role)

--- a/infra/precalculator/tests/unit/test_precalculator_stack.py
+++ b/infra/precalculator/tests/unit/test_precalculator_stack.py
@@ -3,6 +3,16 @@ import aws_cdk.assertions as assertions
 
 from precalculator.precalculator_stack import PrecalculatorStack
 
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+dotenv_path = Path("../../config/settings.env")
+load_dotenv(dotenv_path=dotenv_path)
+
+ATHENA_DATABASE = str(os.getenv("ATHENA_DATABASE"))
+ATHENA_PREDICTION_TABLE = str(os.getenv("ATHENA_PREDICTION_TABLE"))
+
 
 # example tests. To run these tests, uncomment this file along with the example
 # resource in precalculator/precalculator_stack.py
@@ -11,4 +21,6 @@ def test_table_created():
     stack = PrecalculatorStack(app, "precalculator")
     template = assertions.Template.from_stack(stack)
 
-    template.has_resource_properties("AWS::DynamoDB::GlobalTable", {"BillingMode": "PAY_PER_REQUEST"})
+    template.has_resource_properties(
+        "AWS::Athena::Table", {"DatabaseName": ATHENA_DATABASE, "TableName": ATHENA_PREDICTION_TABLE}
+    )

--- a/scripts/fetch_predictions.py
+++ b/scripts/fetch_predictions.py
@@ -3,27 +3,25 @@ import argparse
 import pandas as pd
 
 from config.app import DataLakeConfig
-from precalculator.fetcher import PredictionFetcher
+from precalculator.fetcher import LocalPredictionFetcher
 
 
 def get_parameters() -> dict:
     parser = argparse.ArgumentParser(description="Process parameters.")
-    parser.add_argument("--user", help="User ID")
     parser.add_argument("--request", help="Request ID")
     parser.add_argument("--model", help="Model ID")
 
     args = parser.parse_args()
 
-    params = {"user_id": args.user, "request_id": args.request, "model_id": args.model}
+    params = {"request_id": args.request, "model_id": args.model}
 
     return params
 
 
-def main(user_id: str, request_id: str, model_id: str) -> pd.DataFrame:
+def main(request_id: str, model_id: str) -> pd.DataFrame:
     """Fetch predictions
 
     Args:
-        user_id (str): _description_
         request_id (str): _description_
         model_id (str): _description_
 
@@ -34,7 +32,7 @@ def main(user_id: str, request_id: str, model_id: str) -> pd.DataFrame:
 
     print("config", config)
 
-    fetcher = PredictionFetcher(config, user_id, request_id, model_id)
+    fetcher = LocalPredictionFetcher(config, request_id, model_id)
 
     path_to_input = fetcher.get_s3_input_location()
 
@@ -43,19 +41,6 @@ def main(user_id: str, request_id: str, model_id: str) -> pd.DataFrame:
     df_predictions = fetcher.fetch(path_to_input)
 
     return df_predictions
-
-
-def handler(event: dict, context: dict) -> dict:
-    """Placeholder lambda function which will call main
-
-    Args:
-        event (dict): _description_
-        context (dict): _description_
-
-    Returns:
-        dict: _description_
-    """
-    return {"event": len(event), "context": len(context)}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR:
- Updates existing Lambdas and creates new ones to check for model existence, upload inputs to S3 and into Glue, and gets precalculations via Athena
- Stores output in S3 and returns a presigned URL for CLI users to access an S3 bucket containing their outputs
- Adds IaC via CDK for S3, Lambda, API Gateway, Athena, Glue, and IAM to read predictions from the cloud

Next steps:
- @kartikey-vyas will wrap up this PR by doing some integration testing and documentation
  - The [corresponding PR in the Ersilia repo](https://github.com/ersilia-os/ersilia/pull/1190) allows the public to access the deployed infrastructure and would need to be part of the integration testing as well
- See TODOs in code comments for other things that would be beneficial to do for robustness and maintainability 

Notes:
- The AWS SDK for Pandas ([version 3.9.1](https://github.com/aws/aws-sdk-pandas/releases/tag/3.9.1) works with our repo as of Sep 2024) currently needs to be manually added as a Layer to the fetch_predictions Lambda for AWS Wrangler functionality